### PR TITLE
Fix unmowed lines (#201)

### DIFF
--- a/src/lib/slic3r_coverage_planner/src/coverage_planner.cpp
+++ b/src/lib/slic3r_coverage_planner/src/coverage_planner.cpp
@@ -488,7 +488,7 @@ bool planPath(slic3r_coverage_planner::PlanPathRequest &req, slic3r_coverage_pla
         fill->endpoints_overlap = 0;
         fill->density = 1.0;
         fill->dont_connect = false;
-        fill->dont_adjust = false;
+        fill->dont_adjust = true;
         fill->min_spacing = req.distance;
         fill->complete = false;
         fill->link_max_length = 0;


### PR DESCRIPTION
Several people complained that the mower leaves some space between the lines uncut: https://discord.com/channels/958476543846412329/961804411112394842/1382596496498626672 https://discord.com/channels/958476543846412329/1079054431758332027/1381680934859833464 https://discord.com/channels/958476543846412329/961804411112394842/1380152880165814322

I noticed it for myself as well, but blamed it on the wheels pushing the grass down. I finally did some investigations using my [SVG plotter](https://github.com/rovo89/open_mower_ros/commits/svg/) and an artificial area of 1x2 m and could confirm the issue there.

Here are the plans for 10cm / 20cm / 40cm distance without any outlines: ![image](https://github.com/user-attachments/assets/0fb118f4-8e29-4714-b516-94590da7c13a) 5.01 / 16.26 / 27.5 / 38.75 / 50.0 / 61.25 / 72.5 / 83.74 / 94.99

![image](https://github.com/user-attachments/assets/916d9749-cf6a-4209-b064-588e18abdc9e) 10.01 / 34.01 / 58.01 / 82.01 / 90.0

![image](https://github.com/user-attachments/assets/25f1e177-7a29-4f2c-914a-b750e892e019) 20.01 / 68.01 / 80.0

It's clearly visible that the distance is wrong (11.25 / 24 / 48 cm).

---

Then I found out about this parameter:
```
bool Slic3r::Fill::dont_adjust
Don't adjust spacing to fill the space evenly.
```

Which was set to "false" since 2021 with an explanation of "wip": https://github.com/ClemensElflein/slic3r_coverage_planner/commit/6a10099b311505f437a330f3df32131309633a7b

If set it to "true, i.e. disable adjustments and ask it to use exactly the provided distance, the results are almost as expected: ![image](https://github.com/user-attachments/assets/a30d89ee-f677-44fd-b111-bc3c626bf849) 10.0 / 20.0 / 30.0 / 40.0 / 50.0 / 60.0 / 70.0 / 80.0 / 90.0

![image](https://github.com/user-attachments/assets/4352c2eb-56f8-4e5b-8cd6-84ce00cc0b04) 10.0 / 30.0 / 50.0 / 70.0 / 90.0

![image](https://github.com/user-attachments/assets/6848c5df-df98-40c8-90e7-f449028ba652) 20.0 / 50.0

---

Almost good, but the 40 cm distance can't fill the 100 cm even and that causes unmowed space at end... and I have no idea why it doesn't go to 20/60 cm, leaving 20 instead of 30 cm unmowed.

I'm not sure if this can be solved with slic3r. The solution would probably be to mow the last line with a bit more overlap, which 3D printers probably won't do. Alternatively, we could try to calculate a spacing which equal to or slightly smaller than the configured tool width. But that's not correct either. 33.3333 cm seems like the answer, for which we get 0.167 / 0.5 / 0.833. That's three lines which is the perfect number of lines mowed to cover 100 cm width a 40 cm tool, but it goes beyond the outline a bit. Might be acceptable for outline_count > 0. We'd need to redo some of the work of the slic3r to figure out the total width (seems to be the bounding box after rotating). 

---

Even with this remaining issue, I think it's better than before, because we no longer have a lot of uncut area between the lines, just some in the beginning and/or end.